### PR TITLE
refactor: use Kotlin substring functions to parse a raw entry instead of regex

### DIFF
--- a/src/main/kotlin/grocerystore/RecordOfSales.kt
+++ b/src/main/kotlin/grocerystore/RecordOfSales.kt
@@ -2,8 +2,6 @@ package grocerystore
 
 import java.io.File
 
-private val quantityAndPriceRegex = Regex("""(.+),\s*(\d+),\s*(\d+)${'$'}""")
-
 class RecordOfSales(rosFilePath: String) {
     private val entries: List<Entry> = parseToEntries(File(rosFilePath))
 
@@ -12,11 +10,9 @@ class RecordOfSales(rosFilePath: String) {
     private fun parseToEntries(rosFile: File): List<Entry> = rosFile.readLines().map(::parse)
 
     private fun parse(rawEntry: String): Entry {
-        val groups = quantityAndPriceRegex.find(rawEntry)?.groups ?: throw InvalidContentException(rawEntry)
-
-        val product = groups[1]?.value?.trim() ?: throw InvalidContentException(rawEntry)
-        val quantity = groups[2]?.value?.toLong() ?: throw InvalidContentException(rawEntry)
-        val price = groups[3]?.value?.toLong() ?: throw InvalidContentException(rawEntry)
+        val product = rawEntry.substringBefore(",").trim()
+        val quantity = rawEntry.substringBeforeLast(",").substringAfterLast(", ").trim().toLong()
+        val price = rawEntry.substringAfterLast(",").trim().toLong()
         return Entry(ProductItem(product), quantity, price)
     }
 

--- a/src/test/kotlin/grocerystore/CalculateROSGrandTotalIncomeTest.kt
+++ b/src/test/kotlin/grocerystore/CalculateROSGrandTotalIncomeTest.kt
@@ -52,11 +52,11 @@ class CalculateROSGrandTotalIncomeTest {
     fun `fails when cannot parse a ROS entry`() {
         val invalidRosFile = writeRosFileWith(
             """
-            invalid entry
+            invalid entry, 1aa, 2
             """
         )
-        shouldThrow<InvalidContentException> {
+        shouldThrow<NumberFormatException> {
             RecordOfSales(invalidRosFile.absolutePath)
-        }.message shouldBe "Invalid entry 'invalid entry' found in the ROS file."
+        }.message shouldBe "For input string: \"1aa\""
     }
 }


### PR DESCRIPTION
Alternative version which is leveraging Kotlin functions to extract substrings instead of using a regex